### PR TITLE
New CI

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -9,7 +9,7 @@ on:
 env:
   DOCKER_BUILDCONTEXT: '.'
   DOCKER_FILEPATH: 'Dockerfile'
-  DOCKER_REPOSITORY: ${{ secrets.DOCKER_ORGANIZATION }}
+  DOCKER_REPOSITORY: ${{ github.repository }}
   DOCKER_IMAGE: ${{ github.event.repository.name }}
 
 
@@ -20,8 +20,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: docker/build-push-action@v1
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
           registry: docker.io
           repository: ${{ env.DOCKER_REPOSITORY }}/${{ env.DOCKER_IMAGE }}
           path: ${{ env.DOCKER_BUILDCONTEXT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
 env:
   DOCKER_BUILDCONTEXT: '.'
   DOCKER_FILEPATH: 'Dockerfile'
-  DOCKER_REPOSITORY: ${{ secrets.DOCKER_ORGANIZATION }}
+  DOCKER_REPOSITORY: ${{ github.repository_owner }}
   DOCKER_IMAGE: ${{ github.event.repository.name }}
 
 jobs:


### PR DESCRIPTION
Add new CI please!
# CI/CD on github-actions

This pull requests adds The Linux Foundation docker
toolchain for CI/CD workflows on github-actions.

## Toolchain

The CI/CD workflows for this repository are triggered by the following:

* Pull Requests: Pull requests against master will verify the project
  container can be built. The container won't be pushed anywhere.
* Merge: Merges to the repository build the docker container and tag it
  with ':latest', and 
  push it to dockerhub. 
* Release: On tags, the container is built, tagged with both the
  specified tag and ':latest' and pushed to dockerhub.


## Docker Environment Variables

The following variables are available to workflows:
- `$DOCKER_IMAGE`
  Name of the docker image to create
- `$DOCKER_BUILDCONTEXT`
  Path to the build context for the docker image
- `$DOCKER_FILEPATH`
  Path to the Dockerfile being built
- `$DOCKER_REPOSITORY`
  Name of the docker registry repository where the image will be
  distributed


## Updating this Pull Request

If these workflows don't match the needs for your project feel free to
[modify](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/checking-out-pull-requests-locally)
them to meet your needs.

Signed-off-by: ITX CI \<itx@linuxfoundation.org\>
on-behalf-of: @linuxfoundation-it \<itx@linuxfoundation.org\>